### PR TITLE
Fix/default

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ uv run python main.py
 
 # カスタマイズ実行
 uv run python main.py --source database_entries --analysis domi --delivery console
-uv run python main.py --source recent_documents --analysis aga --delivery file_html
+uv run python main.py --source all --analysis aga --delivery file_html
 uv run python main.py --source database_entries --analysis domi --delivery console,email_text
 uv run python main.py --days 14 --delivery email_html,file_text
 
@@ -76,7 +76,7 @@ uv run python main.py --help
 
 | 引数          | 説明               | 選択肢                        | デフォルト |
 | ----------- | ---------------- | -------------------------- | ----- |
-| `--source`  | データソース         | `database_entries`, `recent_documents` | recent_documents |
+| `--source`  | データソース         | `database_entries`, `all` | all |
 | `--analysis` | 分析タイプ          | `domi`, `aga` | domi |
 | `--delivery` | 配信方法           | `console`, `email_text`, `email_html`, `file_text`, `file_html` | console |
 | `--days`    | 取得日数          | 整数値                        | 7 |

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ EMAIL_PORT=587
 ### 4. 実行
 
 ```bash
-# デフォルト実行（database_entries + domi分析 + console出力）
+# デフォルト実行（all + comprehensive分析 + console出力）
 uv run python main.py
 
 # カスタマイズ実行
@@ -76,7 +76,7 @@ uv run python main.py --help
 
 | 引数          | 説明               | 選択肢                        | デフォルト |
 | ----------- | ---------------- | -------------------------- | ----- |
-| `--source`  | データソース         | `database_entries`, `recent_documents` | database_entries |
+| `--source`  | データソース         | `database_entries`, `recent_documents` | recent_documents |
 | `--analysis` | 分析タイプ          | `domi`, `aga` | domi |
 | `--delivery` | 配信方法           | `console`, `email_text`, `email_html`, `file_text`, `file_html` | console |
 | `--days`    | 取得日数          | 整数値                        | 7 |

--- a/inputs/notion_input.py
+++ b/inputs/notion_input.py
@@ -56,7 +56,7 @@ class NotionInput:
         try:
             response = self._client.search(
                 filter={"value": "page", "property": "object"},
-                sort={"direction": "descending", "timestamp": "created_time"}
+                sort={"direction": "descending", "timestamp": "last_edited_time"}
             )
             
             pages = response.get("results", [])

--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ class PicklesSystem:
         self._logger = Logger()
         
     def run_analysis(self, 
-                    data_source: str = "recent_documents",
+                    data_source: str = "all",
                     analysis_type: str = "comprehensive",
                     delivery_methods: List[str] = None,
                     days: int = 7) -> Dict[str, str]:
@@ -38,7 +38,7 @@ class PicklesSystem:
             delivery_methods = ["console"]
         
         # バリデーション
-        valid_sources = {DataSources.DATABASE_ENTRIES, DataSources.RECENT_DOCUMENTS}
+        valid_sources = {DataSources.DATABASE_ENTRIES, DataSources.ALL}
         if data_source not in valid_sources:
             return {"error": f"未対応のデータソース: {data_source}"}
 
@@ -87,7 +87,7 @@ class PicklesSystem:
         """データ取得"""
         if data_source == DataSources.DATABASE_ENTRIES:
             return self._notion_input.fetch_database_entries(days)
-        elif data_source == DataSources.RECENT_DOCUMENTS:
+        elif data_source == DataSources.ALL:
             return self._notion_input.fetch_recent_documents(days)
         else:
             raise ValueError(f"未対応のデータソース: {data_source}")
@@ -95,7 +95,7 @@ class PicklesSystem:
     def _parse_command_args(self, args: List[str]) -> Dict[str, any]:
         """コマンドライン引数を解析"""
         default_args = {
-            "source": DataSources.RECENT_DOCUMENTS,
+            "source": DataSources.ALL,
             "analysis": AnalysisTypes.DOMI, 
             "delivery": [DeliveryMethods.CONSOLE],
             "days": 7,
@@ -139,7 +139,7 @@ class PicklesSystem:
         # デフォルト設定で週次実行
         default_analysis = partial(
             self.run_analysis,
-            data_source=DataSources.RECENT_DOCUMENTS,
+            data_source=DataSources.ALL,
             analysis_type=AnalysisTypes.DOMI,
             delivery_methods=[DeliveryMethods.CONSOLE, DeliveryMethods.EMAIL_TEXT],
             days=7

--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ class PicklesSystem:
         self._logger = Logger()
         
     def run_analysis(self, 
-                    data_source: str = "database_entries",
+                    data_source: str = "recent_documents",
                     analysis_type: str = "comprehensive",
                     delivery_methods: List[str] = None,
                     days: int = 7) -> Dict[str, str]:
@@ -95,7 +95,7 @@ class PicklesSystem:
     def _parse_command_args(self, args: List[str]) -> Dict[str, any]:
         """コマンドライン引数を解析"""
         default_args = {
-            "source": DataSources.DATABASE_ENTRIES,
+            "source": DataSources.RECENT_DOCUMENTS,
             "analysis": AnalysisTypes.DOMI, 
             "delivery": [DeliveryMethods.CONSOLE],
             "days": 7,
@@ -139,7 +139,7 @@ class PicklesSystem:
         # デフォルト設定で週次実行
         default_analysis = partial(
             self.run_analysis,
-            data_source=DataSources.DATABASE_ENTRIES,
+            data_source=DataSources.RECENT_DOCUMENTS,
             analysis_type=AnalysisTypes.DOMI,
             delivery_methods=[DeliveryMethods.CONSOLE, DeliveryMethods.EMAIL_TEXT],
             days=7

--- a/utils/printer.py
+++ b/utils/printer.py
@@ -49,8 +49,13 @@ class UsagePrinter:
   {CommandArgs.HELP}          このヘルプを表示
 
 例:
+<<<<<<< HEAD
   python main.py                                                                # デフォルト: {DataSources.DATABASE_ENTRIES}
   python main.py {CommandArgs.SOURCE} {DataSources.RECENT_DOCUMENTS} {CommandArgs.ANALYSIS} {AnalysisTypes.DOMI}
+=======
+  python main.py                                                                # デフォルト: {DataSources.RECENT_DOCUMENTS}
+  python main.py {CommandArgs.SOURCE} {DataSources.RECENT_DOCUMENTS} {CommandArgs.ANALYSIS} {AnalysisTypes.COMPREHENSIVE}
+>>>>>>> 5a55b1e (feat: デフォルトではnotionの全体から記事を持ってくるようにした)
   python main.py {CommandArgs.DELIVERY} {DeliveryMethods.CONSOLE},{DeliveryMethods.FILE_HTML} {CommandArgs.DAYS} 14
   python main.py {CommandArgs.SCHEDULE}
         """

--- a/utils/printer.py
+++ b/utils/printer.py
@@ -12,7 +12,7 @@ CommandArgs = SimpleNamespace(
 
 DataSources = SimpleNamespace(
     DATABASE_ENTRIES="database_entries",
-    RECENT_DOCUMENTS="recent_documents"
+    ALL="all"
 )
 
 AnalysisTypes = SimpleNamespace(
@@ -41,7 +41,7 @@ class UsagePrinter:
   python main.py [オプション]
 
 オプション:
-  {CommandArgs.SOURCE}         データソース ({DataSources.DATABASE_ENTRIES} | {DataSources.RECENT_DOCUMENTS})
+  {CommandArgs.SOURCE}         データソース ({DataSources.DATABASE_ENTRIES} | {DataSources.ALL})
   {CommandArgs.ANALYSIS}       分析タイプ ({AnalysisTypes.DOMI} | {AnalysisTypes.AGA})
   {CommandArgs.DELIVERY}       配信方法 ({DeliveryMethods.CONSOLE},{DeliveryMethods.EMAIL_TEXT},{DeliveryMethods.EMAIL_HTML},{DeliveryMethods.FILE_TEXT},{DeliveryMethods.FILE_HTML})
   {CommandArgs.DAYS}          取得日数 (デフォルト: 7)
@@ -49,13 +49,9 @@ class UsagePrinter:
   {CommandArgs.HELP}          このヘルプを表示
 
 例:
-<<<<<<< HEAD
-  python main.py                                                                # デフォルト: {DataSources.DATABASE_ENTRIES}
-  python main.py {CommandArgs.SOURCE} {DataSources.RECENT_DOCUMENTS} {CommandArgs.ANALYSIS} {AnalysisTypes.DOMI}
-=======
-  python main.py                                                                # デフォルト: {DataSources.RECENT_DOCUMENTS}
-  python main.py {CommandArgs.SOURCE} {DataSources.RECENT_DOCUMENTS} {CommandArgs.ANALYSIS} {AnalysisTypes.COMPREHENSIVE}
->>>>>>> 5a55b1e (feat: デフォルトではnotionの全体から記事を持ってくるようにした)
+  python main.py                                                                # デフォルト: {DataSources.ALL}
+  python main.py {CommandArgs.SOURCE} {DataSources.ALL} {CommandArgs.ANALYSIS} {AnalysisTypes.DOMI}
+  python main.py {CommandArgs.SOURCE} {DataSources.DATABASE_ENTRIES} {CommandArgs.ANALYSIS} {AnalysisTypes.AGA}
   python main.py {CommandArgs.DELIVERY} {DeliveryMethods.CONSOLE},{DeliveryMethods.FILE_HTML} {CommandArgs.DAYS} 14
   python main.py {CommandArgs.SCHEDULE}
         """


### PR DESCRIPTION
# 何をやったか
uv run python main.py
を実行したとき、デフォルトで `DATABASE_ENTRIES="database_entries"` になっていたのを `ALL="all"` にしました。

これによって、notion api keyを作成したときに設定した権限範囲内の全てのpageがデフォルトで分析対象になります